### PR TITLE
Fix saba infrastructure to be compatible with astropy 3.2

### DIFF
--- a/saba/conftest.py
+++ b/saba/conftest.py
@@ -2,7 +2,17 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
-from astropy.tests.pytest_plugins import *
+from astropy.version import version as astropy_version
+if astropy_version < '3.0':
+    # With older versions of Astropy, we actually need to import the pytest
+    # plugins themselves in order to make them discoverable by pytest.
+    from astropy.tests.pytest_plugins import *
+else:
+    # As of Astropy 3.0, the pytest plugins provided by Astropy are
+    # automatically made available when Astropy is installed. This means it's
+    # not necessary to import them here, but we still need to import global
+    # variables that are used for configuration.
+    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions
@@ -29,12 +39,13 @@ import os
 # This is to figure out the affiliated package version, rather than
 # using Astropy's
 try:
-    from .version import version
+    from .version import version, astropy_helpers_version
 except ImportError:
     version = 'dev'
 
 try:
     packagename = os.path.basename(os.path.dirname(__file__))
     TESTED_VERSIONS[packagename] = version
+    TESTED_VERSIONS['astropy_helpers'] = astropy_helpers_version
 except NameError:   # Needed to support Astropy <= 1.0.0
     pass

--- a/saba/main.py
+++ b/saba/main.py
@@ -10,9 +10,7 @@ from sherpa.stats import CStat, WStat, Cash
 from sherpa.optmethods import GridSearch, LevMar, MonCar, NelderMead
 from sherpa.estmethods import Confidence, Covariance, Projection
 from sherpa.sim import MCMC
-import warnings
 
-from astropy.extern.six.moves import range
 from astropy.utils import format_doc
 from astropy.utils.exceptions import AstropyUserWarning
 #from astropy.tests.helper import catch_warnings

--- a/setup.py
+++ b/setup.py
@@ -148,7 +148,6 @@ setup(name=PACKAGENAME,
       long_description=LONG_DESCRIPTION,
       cmdclass=cmdclassd,
       zip_safe=False,
-      use_2to3=False,
       entry_points=entry_points,
       python_requires='>={}'.format(__minimum_python_version__),
       **package_info


### PR DESCRIPTION
@hamogu - this fixes the astropy dev build, but not the docs build given that fails with some sherpa related issue.

If travis is not turned on your fork you can find the results here: https://travis-ci.org/bsipocz/saba/builds/531662185